### PR TITLE
add documentation to simulation-benchmarks.ipynb

### DIFF
--- a/ipynb/simulation-benchmark.ipynb
+++ b/ipynb/simulation-benchmark.ipynb
@@ -4,9 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, we will compare the multinomial regression to ANCOM.\n",
+    "Here, we will compare the multinomial regression to ANCOM and ALDEx2.\n",
     "\n",
-    "TODO: Will need both versions of ANCOM benchmarked    "
    ]
   },
   {
@@ -37,6 +36,13 @@
     "import seaborn as sns\n",
     "\n",
     "%matplotlib inline"
+   ]
+  },
+    {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create simulated tables centered around 0 and around -2"
    ]
   },
   {


### PR DESCRIPTION
this is a bit hard for me to read (did you do the ANCOM/ALDEx2 analysis somewhere else?) - I think it would be useful to add in a bit more documentation to make it easier to follow